### PR TITLE
💡Feat : fetch util

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import React,{useState} from 'react'
 import '../styles/Login.css'
 import { useNavigate } from 'react-router-dom'
+import {loginApi} from '../utils/fetchAPI'
 const Login = () => {
   const navigate = useNavigate();
   const [inputs, setInputs] = useState({
@@ -19,24 +20,8 @@ const Login = () => {
   }
   const onSubmit = (e) => {
     e.preventDefault();
-    fetch("http://localhost:8000/api/login",{
-      // 로그인은 데이터 추가는 아니지만, body에 아이디 비밀번호를 보내야 해서 post로 보냅니다. get은 body가 없어요
-      method:"POST",
-      headers:{
-        // 없으면 오류남!
-        "Content-Type":"application/json"
-      },
-      body:JSON.stringify(inputs)
-    }).then(
-      (response)=>{
-        if(!response.ok){
-          throw new Error()
-        }
-        return response.json()}
-    )
-    .then((json)=>{
-      localStorage.setItem('token',json.token)
-    }).then(()=>{
+    loginApi("http://localhost:8000/api/login", inputs)
+    .then(()=>{
       navigate("/personal")
     }).catch(
       (e)=>setError("아이디나 비밀번호가 잘못되었습니다.")

--- a/src/pages/Personal.jsx
+++ b/src/pages/Personal.jsx
@@ -1,55 +1,14 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-
+import {getTokenApi} from '../utils/fetchAPI'
 const Personal = () => {
-  const [myName, setMyname] = useState("")
+  const [myName, setMyName] = useState("")
   const navigate = useNavigate()
-  useEffect(
-    ()=>{
-      if(!localStorage.getItem('token')){
-        alert('올바르지 않은 접근입니다.')
-        navigate('/')
-        return
-      }
-      fetch("http://localhost:8000/api/me",{
-        headers:{
-          "Content-Type":"application/json",
-          "Authorization":`bearer ${localStorage.getItem('token')}`
-        }
-      }).then((response)=>response.json())
-      .then((data)=>{setMyname(data[0].name)})
-      .catch(()=>{
-        console.log("토큰 만료로 다시 시도중")
-        fetch("http://localhost:8000/api/refresh",{
-          headers:{
-            "Content-Type":'application/json',
-            'Authorization':`bearer ${localStorage.getItem('token')}`
-          }
-        }).then((response)=>response.json())
-        .then((data)=>{
-          localStorage.setItem('token',data.newToken)
-          return data.newToken 
-        })
-        .then(
-          (token)=>{
-            fetch("http://localhost:8000/api/me",{
-              headers:{
-                "Content-Type":"application/json",
-                "Authorization":`bearer ${token}`
-              }
-            }).then((response)=> response.json())
-            .then((data)=>{setMyname(data[0].name)})
-            .catch(()=>{
-              localStorage.removeItem('token')
-              alert("로그인이 만료되었습니다. 다시 로그인해주세요")
-              navigate('/')
-            })
-          }
-          
-        )
-      })
-    }
-  )
+  
+  getTokenApi('http://localhost:8000/api/me')
+  .then((response)=>setMyName(response[0].name))
+  
+
   const onClick = () => {
     localStorage.removeItem('token')
     navigate("/")
@@ -63,3 +22,4 @@ const Personal = () => {
 }
 
 export default Personal
+

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,6 +1,7 @@
 import React, { useState }  from 'react'
 import { useNavigate } from 'react-router-dom'
 import '../styles/Register.css'
+import {loginApi, putApi, getApi, postApi, patchApi, deleteApi} from '../utils/fetchAPI'
 const Register = () => {
   const navigate = useNavigate()
   const [inputs, setInputs] = useState({
@@ -27,18 +28,7 @@ const Register = () => {
       return
     }
 
-    fetch("http://localhost:8000/api/register",{
-      method:"POST",
-      headers:{
-        "Content-Type":"application/json"
-      },
-      body:JSON.stringify(inputs)
-    }).then((response)=>{
-      if(!response.ok){
-        throw new Error()
-      }
-      return response.json()})
-    .then((data)=>localStorage.setItem('token',data.token))
+    loginApi("http://localhost:8000/api/register",inputs)
     .then(()=>{
       navigate("/personal")
     }).catch(()=>{

--- a/src/utils/fetchAPI.js
+++ b/src/utils/fetchAPI.js
@@ -1,0 +1,187 @@
+const refreshURL = 'http://localhost:8000/api/refresh'
+const refreshToken = async () => {
+  const token = localStorage.getItem('token')
+  const response = await fetch(refreshURL, {
+    method:"GET",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `bearer ${token}`
+    }
+  });
+  if(!response.ok){
+    throw new Error('Failed to fetch')
+  }
+  const data = await response.json();
+  localStorage.setItem('token',data.newToken)
+  return data.newToken;
+}
+
+export const getApi = async (url) => {
+  const response = await fetch(url, {
+    method:"GET",
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+  if(!response.ok){
+    throw new Error('Failed to fetch')
+  }
+  const data = await response.json();
+  return data;
+}
+export const getTokenApi = async (url) => {
+  const token = localStorage.getItem('token')
+  const response = await fetch(url, {
+    method:"GET",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `bearer ${token}`
+    }
+  });
+  if(!response.ok){
+    const newToken = await refreshToken();
+    const response2 = await fetch(url, {
+      method:"GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `bearer ${newToken}`
+      }
+    });
+    if(!response2.ok){
+      throw new Error("로그인 만료되었거나, 해당 데이터가 없습니다.")
+    }
+    const data2 = await response2.json();
+    return data2;
+  }
+  const data = await response.json();
+  return data;
+}
+export const postApi = async (url,body) => {
+  const token = localStorage.getItem('token')
+  const response = await fetch(url, {
+    method:"POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `bearer ${token}`
+    },
+    body:JSON.stringify(body)
+  });
+  if(!response.ok){
+    const newToken = await refreshToken();
+    const response2 = await fetch(url, {
+      method:"POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `bearer ${newToken}`
+      },
+      body:JSON.stringify(body)
+    });
+    if(!response2.ok){
+      throw new Error("로그인 만료되었거나, 해당 데이터가 없습니다.")
+    }
+    const data2 = await response2.json();
+    return data2;
+  }
+  const data = await response.json();
+  return data;
+}
+export const loginApi = async (url, idAndPassword) => {
+  const response = await fetch(url, {
+    method:"POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body:JSON.stringify(idAndPassword)
+  });
+  if(!response.ok){
+    throw new Error('Failed to fetch')
+  }
+  const data = await response.json();
+  localStorage.setItem('token',data.token)
+  return true
+}
+export const putApi = async (url,body) => {
+  const token = localStorage.getItem('token')
+  const response = await fetch(url, {
+    method:"PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `bearer ${token}`
+    },
+    body:JSON.stringify(body)
+  });
+  if(!response.ok){
+    const newToken = await refreshToken();
+    const response2 = await fetch(url, {
+      method:"PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `bearer ${newToken}`
+      },
+      body:JSON.stringify(body)
+    });
+    if(!response2.ok){
+      throw new Error("로그인 만료되었거나, 해당 데이터가 없습니다.")
+    }
+    const data2 = await response2.json();
+    return data2;
+  }
+  const data = await response.json();
+  return data;
+}
+export const patchApi = async (url,body) => {
+  const token = localStorage.getItem('token')
+  const response = await fetch(url, {
+    method:"PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `bearer ${token}`
+    },
+    body:JSON.stringify(body)
+  });
+  if(!response.ok){
+    const newToken = await refreshToken();
+    const response2 = await fetch(url, {
+      method:"PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `bearer ${newToken}`
+      },
+      body:JSON.stringify(body)
+    });
+    if(!response2.ok){
+      throw new Error("로그인 만료되었거나, 해당 데이터가 없습니다.")
+    }
+    const data2 = await response2.json();
+    return data2;
+  }
+  const data = await response.json();
+  return data;
+}
+export const deleteApi = async (url) => {
+  const token = localStorage.getItem('token')
+  const response = await fetch(url, {
+    method:"DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `bearer ${token}`
+    }
+  });
+  if(!response.ok){
+    const newToken = await refreshToken();
+    const response2 = await fetch(url, {
+      method:"DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `bearer ${newToken}`
+      }
+    });
+    if(!response2.ok){
+      throw new Error("로그인 만료되었거나, 해당 데이터가 없습니다.")
+    }
+    const data2 = await response2.json();
+    return data2;
+  }
+  const data = await response.json();
+  return data;
+}


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
새로운 유틸 생성

### 상세 내용(Describe your changes)
1. 서버에 요청을 보낼 때, 헤더에 입력해야하는 정보가 너무 많았습니다.
      "Content-Type": "application/json",
      "Authorization": `bearer ${token}`
이걸 매번 입력하지 않도록 만들었습니다.

2.  토큰을 refresh 하는 과정이 너무 번거롭습니다. 
원래는 일단 토큰을 넣어서 요청을 보내보고, 만약 실패한다면, api/refresh로 요청을 보내서 토큰을 새로 받은 뒤, 다시 원래 요청을 보내려고 했던 곳으로 보내야하는데, 이 과정을 매번 하면 너무 귀찮아서 자동적으로 요청을 보낸 후에, 실패하면 토큰을 새로고침하고, 원래 요청을 보내려던 곳으로 다시 보냅니다.

3. patch가 작동을 안 하는데 이건 백엔드 문제인거 같아서 수정이 필요할 거 같습니다.
### Issue Number or Link
